### PR TITLE
OS-8701 smartos-live (and node-0.10 of node-fs-ext) need to freeze "nan" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "~2.14.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
Blocks TritonDataCenter/smartos-live#1162